### PR TITLE
🔪🐜

### DIFF
--- a/src/pages/index.svelte
+++ b/src/pages/index.svelte
@@ -4,6 +4,9 @@
   import Paper from "./_paper.svelte";
   import Posts from "./_posts.svelte";
   import Footer from "./_footer.svelte";
+
+  $: document.title = "Hello, World!! - @Nagatani";
+
 </script>
 
 <main>


### PR DESCRIPTION
Markdownの個別ページからトップページに戻ってきた場合に、タイトルタグがそのまま残ってしまっていた不具合を修正